### PR TITLE
Problems on migration rollback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "autoload": {
         "classmap": [
             "src/migrations"
-        ]
+        ],
         "psr-0": {
             "Tappleby\\AuthToken": "src/",
             "Tappleby\\Support": "src/"


### PR DESCRIPTION
It's not possible to rollback because the following error occurs:

PHP Fatal error:  Class 'CreateAuthTokenTable' not found in /Users/leandro/rich/novo/quiz/vendor/laravel/framework/src/Illuminate/Database/Migrations/Migrator.php on line 301
{"error":{"type":"Symfony\Component\Debug\Exception\FatalErrorException","message":"Class 'CreateAuthTokenTable' not found","file":"\/Users\/leandro\/rich\/novo\/quiz\/vendor\/laravel\/framework\/src\/Illuminate\/Database\/Migrations\/Migrator.php","line":301}}

I was able to rollback adding the following autoload classmap entry to my composer.json: "vendor/tappleby/laravel-auth-token/src/migrations". It works but I think it's better if it stays on the laravel-auth-token's composer.json.
