### PR TITLE
Add backslash to use main Request object

### DIFF
--- a/src/Tappleby/AuthToken/AuthTokenController.php
+++ b/src/Tappleby/AuthToken/AuthTokenController.php
@@ -40,7 +40,7 @@ class AuthTokenController extends Controller {
 
   protected function getAuthToken() {
 
-	  $token = Request::header('X-Auth-Token');
+	  $token = \Request::header('X-Auth-Token');
 
 	  if(empty($token)) {
 		  $token = Input::get('auth_token');


### PR DESCRIPTION
Without this backslash Route::get('auth', 'Tappleby\AuthToken\AuthTokenController@index'); not working.
