### PR TITLE
Allow Laravel 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.1.x"
+        "illuminate/support": "~4.1"
     },
 
     "require-dev": {


### PR DESCRIPTION
I didn't try your package and not sure if it works on 4.2, but 4.2 has just been released so you probably want to provide support to 4.2
There aren't too many breaking changes in 4.2, so chances are this will work perfectly.
