### PR TITLE
Update AuthTokenManager.php

### DIFF
--- a/src/Tappleby/AuthToken/AuthTokenManager.php
+++ b/src/Tappleby/AuthToken/AuthTokenManager.php
@@ -27,7 +27,7 @@ class AuthTokenManager extends Manager {
     return new DatabaseAuthTokenProvider($connection, 'ta_auth_tokens', $encrypter, $hasher);
   }
 
-  protected function getDefaultDriver() {
+  public function getDefaultDriver() {
     return 'database';
   }
 }


### PR DESCRIPTION
Fixes Laravel complaining that Access level to Tappleby\AuthToken\AuthTokenManager::getDefaultDriver() must be public (as in class Illuminate\Support\Manager).
